### PR TITLE
feat: disable basic auth in prerender context

### DIFF
--- a/src/runtime/server/middleware/basic-auth.ts
+++ b/src/runtime/server/middleware/basic-auth.ts
@@ -6,6 +6,16 @@ export default defineEventHandler((event) => {
   const config = useRuntimeConfig().basicAuth as ModuleRuntimeConfig;
 
   /**
+   * If the request is a prerender request, do nothing.
+   */
+  if (
+    event.node.req.headers?.["x-nitro-prerender"] &&
+    import.meta.env.NODE_ENV === "prerender"
+  ) {
+    return;
+  }
+
+  /**
    * If the module is not enabled, or no users are defined, or the current route is allowed, do nothing.
    */
   if (


### PR DESCRIPTION
Disables the plugin if the `NODE_ENV` is `prerender` and the request contains the `x-nitro-prerender` header.

Solves #2 