### PR TITLE
feat: allow disabled state at build time

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -43,11 +43,9 @@ export default defineNuxtModule<ModuleOptions>({
     /**
      * Add the server middleware to the Nuxt instance
      */
-    if (options.enabled) {
-      addServerHandler({
-        middleware: true,
-        handler: resolve("./runtime/server/middleware/basic-auth"),
-      });
-    }
+    addServerHandler({
+      middleware: true,
+      handler: resolve("./runtime/server/middleware/basic-auth"),
+    });
   },
 });


### PR DESCRIPTION
This pull request removes the current requirement that the module must be enabled at build time in order to be available at runtime.

This change gives developers more flexibility: the module can now be initialized in a disabled state and later enabled at runtime.